### PR TITLE
[WIP]feat(organization-users): prototype CRUD Users - #52 (#107)

### DIFF
--- a/src/GovITHub.Auth.Admin/Controllers/Api/UsersController.cs
+++ b/src/GovITHub.Auth.Admin/Controllers/Api/UsersController.cs
@@ -1,0 +1,72 @@
+﻿using GovITHub.Auth.Common.Data;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GovITHub.Auth.Admin.Controllers.Api
+{
+    [Authorize(Policy = "LinkedToOrganizationPolicy")]
+    [Route("api/organizations/{organizationId}/[controller]")]
+    public class UsersController : ControllerBase
+    {
+        private readonly Common.Data.Contract.IOrganizationUserRepository organizationUserRepository;
+
+        public UsersController(Common.Data.Contract.IOrganizationUserRepository organizationUserRepository)
+        {
+            this.organizationUserRepository = organizationUserRepository;
+        }
+
+        [HttpGet]
+        public IActionResult Get([FromRoute]long organizationId, [FromQuery]int currentPage, [FromQuery]int itemsPerPage, [FromQuery]bool sortAscending, [FromQuery]string sortBy)
+        {
+            ModelQueryFilter filter = new ModelQueryFilter(currentPage, itemsPerPage, sortAscending, sortBy);
+
+            return new ObjectResult(organizationUserRepository.Filter(organizationId, filter));
+        }
+
+        [HttpGet("{id}")]
+        public IActionResult Get([FromRoute]long organizationId, [FromRoute]long id)
+        {
+            Common.Data.Contract.OrganizationUser organizationUser = organizationUserRepository.Find(organizationId, id);
+
+            return Ok(new Models.User()
+            {
+                Id = organizationUser.Id,
+                Level = organizationUser.Level,
+                Status = (Models.UserStatus)organizationUser.Status,
+                Name = organizationUser.Name
+            });
+        }
+
+        [HttpPost]
+        public void Post([FromRoute]long organizationId, [FromBody]Models.User user)
+        {
+            organizationUserRepository.Add(new Common.Data.Contract.OrganizationUser()
+            {
+                Id = user.Id,
+                OrganizationId = organizationId,
+                Name = user.Name,
+                Level = user.Level,
+                Status = (short)user.Status
+            });
+        }
+
+        [HttpPut("{id}")]
+        public void Put([FromRoute]long organizationId, [FromBody]Models.User user)
+        {
+            organizationUserRepository.Update(new Common.Data.Contract.OrganizationUser()
+            {
+                Id = user.Id,
+                OrganizationId = organizationId,
+                Name = user.Name,
+                Level = user.Level,
+                Status = (short)user.Status
+            });
+        }
+
+        [HttpDelete("{id}")]
+        public void Delete([FromRoute]long organizationId, [FromRoute]long id)
+        {
+            organizationUserRepository.Delete(organizationId, id);
+        }
+    }
+}

--- a/src/GovITHub.Auth.Admin/Controllers/Mvc/AccountController.cs
+++ b/src/GovITHub.Auth.Admin/Controllers/Mvc/AccountController.cs
@@ -22,6 +22,6 @@ namespace GovITHub.Auth.Admin.Controllers
         {
             return View();
         }
-        
+
     }
 }

--- a/src/GovITHub.Auth.Admin/Framework/Policy/LinkedToOrganizationHandler.cs
+++ b/src/GovITHub.Auth.Admin/Framework/Policy/LinkedToOrganizationHandler.cs
@@ -1,0 +1,42 @@
+﻿using GovITHub.Auth.Admin.Services;
+using GovITHub.Auth.Common.Data;
+using IdentityModel;
+using Microsoft.AspNetCore.Authorization;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace GovITHub.Auth.Admin.Framework.Policy
+{
+    public class LinkedToOrganizationRequirement : IAuthorizationRequirement
+    { }
+
+    public class LinkedToOrganizationHandler : AuthorizationHandler<LinkedToOrganizationRequirement>
+    {
+        private readonly ApplicationDbContext dbContext;
+
+        public LinkedToOrganizationHandler(ApplicationDbContext dbContext)
+        {
+            this.dbContext = dbContext;
+        }
+
+        protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, LinkedToOrganizationRequirement requirement)
+        {
+            Microsoft.AspNetCore.Routing.RouteValueDictionary routeValues = ((Microsoft.AspNetCore.Mvc.ActionContext)context.Resource).RouteData.Values;
+
+            long organizationId;
+            if (context.TryGetRouteValue("organizationId", out organizationId) && UserLinkedToOrganization(context, organizationId))
+            {
+                context.Succeed(requirement);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        private bool UserLinkedToOrganization(AuthorizationHandlerContext context, long organizationId)
+        {
+            string userName = context.User.Claims.GetClaim(JwtClaimTypes.Name);
+
+            return dbContext.OrganizationUsers.Any(x => x.OrganizationId == organizationId && x.User.UserName == userName);
+        }
+    }
+}

--- a/src/GovITHub.Auth.Admin/Models/User.cs
+++ b/src/GovITHub.Auth.Admin/Models/User.cs
@@ -1,0 +1,13 @@
+﻿namespace GovITHub.Auth.Admin.Models
+{
+    public class User
+    {
+        public long Id { get; set; }
+
+        public string Name { get; set; }
+
+        public Common.Data.Models.OrganizationUserLevel Level { get; set; }
+
+        public UserStatus Status { get; set; }
+    }
+}

--- a/src/GovITHub.Auth.Admin/Models/UserStatus.cs
+++ b/src/GovITHub.Auth.Admin/Models/UserStatus.cs
@@ -1,0 +1,8 @@
+﻿namespace GovITHub.Auth.Admin.Models
+{
+    public enum UserStatus
+    {
+        Inactiv = 0,
+        Activ = 1,
+    }
+}

--- a/src/GovITHub.Auth.Admin/Services/AuthorizationHandlerContextExtensions.cs
+++ b/src/GovITHub.Auth.Admin/Services/AuthorizationHandlerContextExtensions.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.AspNetCore.Authorization;
+
+namespace GovITHub.Auth.Admin.Services
+{
+    public static class AuthorizationHandlerContextExtensions
+    {
+        public static bool TryGetRouteValue<T>(this AuthorizationHandlerContext context, string key, out T value)
+        {
+            Microsoft.AspNetCore.Routing.RouteValueDictionary routeValues = ((Microsoft.AspNetCore.Mvc.ActionContext)context.Resource).RouteData.Values;
+
+            object returnValue;
+            if (routeValues.TryGetValue(key, out returnValue))
+            {
+                value = (T)System.Convert.ChangeType(returnValue, typeof(T));
+
+                return true;
+            }
+            else
+            {
+                value = default(T);
+
+                return false;
+            }
+        }
+    }
+}

--- a/src/GovITHub.Auth.Admin/Startup.cs
+++ b/src/GovITHub.Auth.Admin/Startup.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.IdentityModel.Tokens.Jwt;
-using System.Reflection;
-using System.Threading.Tasks;
-using GovITHub.Auth.Admin.Services;
+﻿using GovITHub.Auth.Admin.Services;
 using GovITHub.Auth.Admin.Services.Impl;
 using GovITHub.Auth.Common;
 using GovITHub.Auth.Common.Data;
@@ -16,6 +12,10 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using MySQL.Data.Entity.Extensions;
+using System;
+using System.IdentityModel.Tokens.Jwt;
+using System.Reflection;
+using System.Threading.Tasks;
 
 namespace GovITHub.Auth.Admin
 {
@@ -38,7 +38,7 @@ namespace GovITHub.Auth.Admin
         public void ConfigureServices(IServiceCollection services)
         {
             string mySqlConnectionString = Configuration.GetConnectionString("DefaultConnection");
-            var migrationsAssembly = typeof(ApplicationUser).GetTypeInfo().Assembly.GetName().Name;      
+            var migrationsAssembly = typeof(ApplicationUser).GetTypeInfo().Assembly.GetName().Name;
 
             services.
                 AddEntityFramework().
@@ -48,13 +48,21 @@ namespace GovITHub.Auth.Admin
 
             services.AddSingleton<ISampleRepository, SampleRepository>();
             services.AddTransient<IOrganizationRepository, OrganizationRepository>();
+            services.AddTransient<Common.Data.Contract.IOrganizationUserRepository, OrganizationUserRepository>();
             services.AddTransient<IUserClaimsExtender, UserClaimsExtender>();
 
             // Add auth common services
             services.AddAuthCommonServices(Configuration);
+
+            services.AddAuthorization(options =>
+            {
+                options.AddPolicy("LinkedToOrganizationPolicy", policy => policy.Requirements.Add(new Framework.Policy.LinkedToOrganizationRequirement()));
+            });
+
+            services.AddSingleton<Microsoft.AspNetCore.Authorization.IAuthorizationHandler, Framework.Policy.LinkedToOrganizationHandler>();
         }
 
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env, 
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env,
             ILoggerFactory loggerFactory, IUserClaimsExtender userClaimsExtender)
         {
             JwtSecurityTokenHandler.DefaultInboundClaimTypeMap.Clear();

--- a/src/GovITHub.Auth.Admin/wwwroot/app/components/common/navigation.html
+++ b/src/GovITHub.Auth.Admin/wwwroot/app/components/common/navigation.html
@@ -1,35 +1,36 @@
 <nav class="navbar-default navbar-static-side" role="navigation">
-	<div class="sidebar-collapse">
-		<ul side-navigation class="nav metismenu" id="side-menu">
-			<li class="nav-header">
-
-				<div class="profile-element" uib-dropdown>
-					<a uib-dropdown-toggle="" href>
-						<span class="clear">
-                                <span class="block m-t-xs">
-                                    <strong class="font-bold">{{main.organizationName}}</strong>
-                             </span>
-						<span class="text-muted text-xs block">Example menu<b class="caret"></b></span>
-						</span>
-					</a>
-					<ul uib-dropdown-menu class="animated flipInX m-t-xs">
-						<li><a href="/account/logout">Logout</a></li>
-					</ul>
-				</div>
-				<div class="logo-element">
-					M/5
-				</div>
-
-			</li>
-			<li ui-sref-active="active">
-				<a ui-sref="index.main"><i aria-hidden="true" class="fa fa-laptop"></i> <span class="nav-label">Dashboard</span> </a>
-			</li>
+    <div class="sidebar-collapse">
+        <ul side-navigation class="nav metismenu" id="side-menu">
+            <li class="nav-header">
+                <div class="profile-element" uib-dropdown>
+                    <a uib-dropdown-toggle="" href>
+                        <span class="clear">
+                            <span class="block m-t-xs">
+                                <strong class="font-bold">{{main.organizationName}}</strong>
+                            </span>
+                            <span class="text-muted text-xs block">Example menu<b class="caret"></b></span>
+                        </span>
+                    </a>
+                    <ul uib-dropdown-menu class="animated flipInX m-t-xs">
+                        <li><a href="/account/logout">Logout</a></li>
+                    </ul>
+                </div>
+                <div class="logo-element">
+                    M/5
+                </div>
+            </li>
+            <li ui-sref-active="active">
+                <a ui-sref="index.main"><i aria-hidden="true" class="fa fa-laptop"></i> <span class="nav-label">Dashboard</span> </a>
+            </li>
             <li ui-sref-active="active">
                 <a ui-sref="index.samples"><i aria-hidden="true" class="fa fa-barcode"></i> <span class="nav-label">Samples</span></a>
             </li>
             <li ui-sref-active="active">
                 <a ui-sref="index.organizations"><i aria-hidden="true" class="fa fa-barcode"></i> <span class="nav-label">Organizatii</span></a>
             </li>
-		</ul>
-	</div>
+            <li ui-sref-active="active">
+                <a ui-sref="index.users"><i aria-hidden="true" class="fa fa-barcode"></i> <span class="nav-label">Utilizatori</span></a>
+            </li>
+        </ul>
+    </div>
 </nav>

--- a/src/GovITHub.Auth.Admin/wwwroot/app/components/users/edit.controller.js
+++ b/src/GovITHub.Auth.Admin/wwwroot/app/components/users/edit.controller.js
@@ -1,0 +1,66 @@
+(function () {
+    'use strict';
+
+    angular
+        .module('authAdminPanel')
+        .controller('UsersEditController', UsersEditController);
+
+    UsersEditController.$inject = ["User", "$state", "$scope", 'status', 'id'];
+
+    function UsersEditController(User, $state, $scope, status, id) {
+        var vm = this;
+        vm.data = {};
+        vm.status = status;
+        vm.id = id;
+
+        vm.save = function () {
+            if (vm.status.edit && vm.id) {
+                update();
+            } else {
+                create();
+            }
+        };
+
+        vm.init = function () {
+            User.get({ id: vm.id, organizationId: $scope.currentUser.organizationId }).$promise
+                .then(function (result) {
+                    vm.data = result;
+                }).catch(function (err) {
+                    vm.error = err;
+                    console.error(err);
+                });
+        };
+
+        var create = function () {
+            User
+                .save({ organizationId: $scope.currentUser.organizationId }, vm.data).$promise
+                .then(function (result) {
+                    $state.go('index.users');
+                }).catch(function (err) {
+                    vm.error = err;
+                    console.error(err);
+                    alert(err.statusText);
+                });
+        };
+
+        var update = function () {
+            User
+                .update({ id: vm.id, organizationId: $scope.currentUser.organizationId }, vm.data).$promise
+                .then(function (result) {
+                    $state.go('index.users');
+                }).catch(function (err) {
+                    vm.error = err;
+                    console.error(err);
+                    alert(err.statusText);
+                });
+        }
+
+        if (vm.status.edit) {
+            vm.init();
+        };
+
+        $scope.$on('$destroy', function () {
+            vm.data = {};
+        });
+    };
+})();

--- a/src/GovITHub.Auth.Admin/wwwroot/app/components/users/edit.html
+++ b/src/GovITHub.Auth.Admin/wwwroot/app/components/users/edit.html
@@ -1,0 +1,63 @@
+﻿<form name="organizationForm" novalidate>
+    <div class="row wrapper border-bottom white-bg page-heading">
+        <div class="col-sm-4">
+            <h2>Utilizatori</h2>
+            <ol class="breadcrumb">
+                <li>
+                    <a ui-sref="index.main">Home</a>
+                </li>
+                <li>
+                    <a ui-sref="index.users">Utilizatori</a>
+                </li>
+                <li>
+                    {{ (vm.status.edit) ? 'Edit' : 'Create' }}
+                </li>
+                <!--<li class="active">
+                    <strong>{{  vm.status.type  }}</strong>
+                </li>-->
+            </ol>
+        </div>
+        <div class="col-sm-8">
+            <div class="title-action">
+                <a class="btn btn-primary btn-sm" ng-click="organizationForm.$valid && vm.save()"><i class="fa fa-save"></i> Salvează</a>
+            </div>
+        </div>
+    </div>
+    <div class="wrapper wrapper-content animated fadeInRight">
+        <div class="row">
+            <div class="col-lg-7">
+                <div class="ibox float-e-margins">
+                    <div class="ibox-content">
+                        <div class="row">
+                            <div class="col-sm-12 b-r">
+                                <div class="form-group">
+                                    <label>Nume</label>
+                                    <span ng-messages="organizationForm.name.$error" class="has-error">
+                                        <span ng-message="required"> (obligatoriu)</span>
+                                        <span ng-message="maxlength"> (Numarul maxim de caractere 200)</span>
+                                    </span>
+                                    <input type="text" name="name" placeholder="gheorghe@ioan.ro"
+                                           ng-model="vm.data.name" ng-maxlength="200" class="form-control" required>
+                                </div>
+                                <div class="form-group">
+                                    <label>Level</label>
+                                    <select ng-model="vm.data.level" class="form-control" convert-to-number>
+                                        <option value="0">Admin</option>
+                                        <option value="100">User</option>
+                                    </select>
+                                </div>
+                                <div class="form-group">
+                                    <label>Status</label>
+                                    <select ng-model="vm.data.status" class="form-control" convert-to-number>
+                                        <option value="1">Activ</option>
+                                        <option value="0">Inactiv</option>
+                                    </select>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</form>

--- a/src/GovITHub.Auth.Admin/wwwroot/app/components/users/list.controller.js
+++ b/src/GovITHub.Auth.Admin/wwwroot/app/components/users/list.controller.js
@@ -1,0 +1,62 @@
+﻿(function () {
+    'use strict';
+
+    angular
+        .module('authAdminPanel')
+        .controller('UsersListController', UsersListController);
+
+    UsersListController.$inject = ['User', '$rootScope', '$log', '$scope', 'UserIdentityService']
+
+    function UsersListController(User, $rootScope, $log, $scope, UserIdentityService) {
+
+        var vm = this;
+        vm.pagination = {
+            currentPage: 1,
+            itemsPerPage: 10,
+            totalItems: 150,
+            maxDisplayedPages: 5
+        };
+        vm.sortBy = 'Name';
+        vm.sortAscending = true;
+
+        vm.search = function () {
+            User.filter({
+                q: vm.query,
+                currentPage: vm.pagination.currentPage,
+                itemsPerPage: vm.pagination.itemsPerPage,
+                sortBy: vm.sortBy,
+                sortAscending: vm.sortAscending,
+                organizationId: $scope.currentUser.organizationId
+            }).$promise
+                .then(function (result) {
+                    vm.items = result.list;
+                    vm.pagination.totalItems = result.totalItems
+                }).catch(function (err) {
+                    $log.error(err);
+                    vm.error = err;
+                });
+        };
+
+        vm.sort = function (sortBy) {
+            vm.sortBy = sortBy;
+            vm.sortAscending = !vm.sortAscending;
+            vm.search();
+        };
+
+        vm.gotoEdit = function (id) {
+            $rootScope.goto('index.users_edit', { id: id });
+        };
+
+        vm.delete = function (id) {
+            User.delete({ id: id, organizationId: $scope.currentUser.organizationId }).$promise
+                .then(function (response) {
+                    vm.search();
+                }).catch(function (err) {
+                    $log.error(err);
+                    vm.error = err;
+                });
+        };
+
+        vm.search();
+    };
+})();

--- a/src/GovITHub.Auth.Admin/wwwroot/app/components/users/list.html
+++ b/src/GovITHub.Auth.Admin/wwwroot/app/components/users/list.html
@@ -1,0 +1,131 @@
+﻿<div class="row wrapper border-bottom white-bg page-heading">
+    <div class="col-sm-8">
+        <h2>Utilizatori</h2>
+        <ol class="breadcrumb">
+            <li>
+                <a ui-sref="index.main">Home</a>
+            </li>
+            <li class="active">
+                <strong>Utilizatori</strong>
+            </li>
+        </ol>
+    </div>
+    <div class="col-sm-4">
+        <div class="title-action">
+            <a ng-click="$root.goto('index.users_new')" class="btn btn-primary btn-sm"><i class="fa fa-plug"></i> Adaugă utilizator</a>
+        </div>
+    </div>
+</div>
+
+<div class="wrapper wrapper-content animated fadeInRight ecommerce">
+    <div class="ibox-content m-b-sm border-bottom">
+        <form name='votingStationsSearchForm' ng-submit="vm.search()" novalidate>
+            <div class="row">
+                <div class="col-sm-1">
+                    <div class="form-group">
+                        <label class="control-label">Id</label>
+                        <!--<input type="text" name="product_name" placeholder="ex: 354" class="form-control" ng-model="vm.query.crt">-->
+                    </div>
+                </div>
+                <div class="col-sm-2">
+                    <div class="form-group">
+                        <label class="control-label">Nume</label>
+                        <!--<input type="text " id="price" name="price" placeholder="ex: Albania" class="form-control" ng-model="vm.query.country">-->
+                    </div>
+                </div>
+                <div class="col-sm-2">
+                    <div class="form-group">
+                        <label class="control-label">Level</label>
+                        <!--<input type="text" id="quantity " name="quantity" placeholder="ex Tirana" class="form-control" ng-model="vm.query.city">-->
+                    </div>
+                </div>
+                <div class="col-sm-2">
+                    <div class="form-group">
+                        <label class="control-label">Status</label>
+                        <!--<input type="text" id="quantity " name="quantity" placeholder="ex Tirana" class="form-control" ng-model="vm.query.city">-->
+                    </div>
+                </div>
+            </div>
+            <div class="row">
+                <div class="col-sm-12">
+                    <input type="submit" class="btn btn-primary pull-right" value="Caută" />
+                </div>
+            </div>
+        </form>
+    </div>
+
+    <div class="row">
+        <div class="col-lg-12">
+            <div class="ibox">
+                <div class="ibox-content">
+                    <table class="footable table table-stripped toggle-arrow-tiny " data-page-size="15">
+                        <thead>
+                            <tr>
+                                <th>
+                                    <a ng-click="vm.sort('id')">
+                                        Id
+                                        <span ng-show="vm.sortBy === 'key' && vm.sortAscending === true " class="fa fa-caret-up "></span>
+                                        <span ng-show="vm.sortBy === 'key' && vm.sortAscending === false " class="fa fa-caret-down "></span>
+                                    </a>
+                                </th>
+                                <th>
+                                    <a ng-click="vm.sort('name')">
+                                        Nume
+                                        <span ng-show="vm.sortBy === 'name' && vm.sortAscending === true " class="fa fa-caret-up "></span>
+                                        <span ng-show="vm.sortBy === 'name' && vm.sortAscending === false " class="fa fa-caret-down "></span>
+                                    </a>
+                                </th>
+                                <th>
+                                    <a ng-click="vm.sort('level')">
+                                        Level
+                                        <span ng-show="vm.sortBy === 'level' && vm.sortAscending === true " class="fa fa-caret-up "></span>
+                                        <span ng-show="vm.sortBy === 'level' && vm.sortAscending === false " class="fa fa-caret-down "></span>
+                                    </a>
+                                </th>
+                                <th>
+                                    <a ng-click="vm.sort('status')">
+                                        Status
+                                        <span ng-show="vm.sortBy === 'status' && vm.sortAscending === true " class="fa fa-caret-up "></span>
+                                        <span ng-show="vm.sortBy === 'status' && vm.sortAscending === false " class="fa fa-caret-down "></span>
+                                    </a>
+                                </th>
+                                <th>
+
+                                </th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr ng-repeat="item in vm.items track by $index ">
+                                <td>
+                                    {{ item.id }}
+                                </td>
+                                <td>
+                                    {{ item.name }}
+                                </td>
+                                <td>
+                                    {{ item.level == 0 ? 'Admin' : 'User' }}
+                                </td>
+                                <td>
+                                    {{ item.status == 0 ? 'Inactiv' : 'Activ' }}
+                                </td>
+                                <td class="text-right">
+                                    <div class="btn-group">
+                                        <button class="btn-white btn btn-xs" ng-click="vm.gotoEdit(item.id)">Modifică</button>
+                                        <button class="btn-danger btn btn-xs" ng-click="vm.delete(item.id)">Șterge</button>
+                                    </div>
+                                </td>
+                            </tr>
+                        </tbody>
+                        <tfoot>
+                            <tr>
+                                <td colspan="6">
+                                    <ul ng-change="vm.search()" uib-pagination total-items="vm.pagination.totalItems" ng-model="vm.pagination.currentPage" max-size="vm.pagination.maxDisplayedPages" class="pagination-sm" boundary-links="true" force-ellipses="true"></ul>
+                                </td>
+                            </tr>
+                        </tfoot>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/GovITHub.Auth.Admin/wwwroot/app/components/users/organization-user.factory.js
+++ b/src/GovITHub.Auth.Admin/wwwroot/app/components/users/organization-user.factory.js
@@ -1,0 +1,16 @@
+﻿(function () {
+    'use strict';
+
+    angular
+        .module('authAdminPanel')
+        .factory("User", User);
+
+    User.$inject = ['$resource'];
+
+    function User($resource) {
+        return $resource('/api/organizations/:organizationId/users/:id', { organizationId: 'organizationId', id: '@id' }, {
+            filter: { method: 'GET' },
+            update: { method: 'PUT' }
+        });
+    };
+})();

--- a/src/GovITHub.Auth.Admin/wwwroot/app/directives.js
+++ b/src/GovITHub.Auth.Admin/wwwroot/app/directives.js
@@ -1,42 +1,56 @@
-'use strict';
+(function () {
+    'use strict';
 
-//Directive used to set metisMenu and minimalize button
-angular.module('authAdminPanel')
-    .directive('sideNavigation', function ($timeout) {
-        return {
-            restrict: 'A',
-            link: function (scope, element) {
-                // Call metsi to build when user signup
-                scope.$watch('authentication.user', function() {
-                    $timeout(function() {
-                        element.metisMenu();
-                    });
-                });
-
-            }
-        };
-    })
-    .directive('minimalizaSidebar', function ($timeout) {
-        return {
-            restrict: 'A',
-            template: '<a class="navbar-minimalize minimalize-styl-2 btn btn-primary " href="" ng-click="minimalize()"><i class="fa fa-bars"></i></a>',
-            controller: function ($scope) {
-                $scope.minimalize = function () {
-                    angular.element('body').toggleClass('mini-navbar');
-                    if (!angular.element('body').hasClass('mini-navbar') || angular.element('body').hasClass('body-small')) {
-                        // Hide menu in order to smoothly turn on when maximize menu
-                        angular.element('#side-menu').hide();
-                        // For smoothly turn on menu
+    //Directive used to set metisMenu and minimalize button
+    angular
+        .module('authAdminPanel')
+        .directive('sideNavigation', function ($timeout) {
+            return {
+                restrict: 'A',
+                link: function (scope, element) {
+                    // Call metsi to build when user signup
+                    scope.$watch('authentication.user', function () {
                         $timeout(function () {
-                            angular.element('#side-menu').fadeIn(400);
-                        }, 200);
-                    } else {
-                        // Remove all inline style from jquery fadeIn function to reset menu state
-                        angular.element('#side-menu').removeAttr('style');
-                    }
-                };
-            }
-        };
-    });
+                            element.metisMenu();
+                        });
+                    });
 
-
+                }
+            };
+        })
+        .directive('minimalizaSidebar', function ($timeout) {
+            return {
+                restrict: 'A',
+                template: '<a class="navbar-minimalize minimalize-styl-2 btn btn-primary " href="" ng-click="minimalize()"><i class="fa fa-bars"></i></a>',
+                controller: function ($scope) {
+                    $scope.minimalize = function () {
+                        angular.element('body').toggleClass('mini-navbar');
+                        if (!angular.element('body').hasClass('mini-navbar') || angular.element('body').hasClass('body-small')) {
+                            // Hide menu in order to smoothly turn on when maximize menu
+                            angular.element('#side-menu').hide();
+                            // For smoothly turn on menu
+                            $timeout(function () {
+                                angular.element('#side-menu').fadeIn(400);
+                            }, 200);
+                        } else {
+                            // Remove all inline style from jquery fadeIn function to reset menu state
+                            angular.element('#side-menu').removeAttr('style');
+                        }
+                    };
+                }
+            };
+        })
+        .directive('convertToNumber', function () {
+            return {
+                require: 'ngModel',
+                link: function (scope, element, attrs, ngModel) {
+                    ngModel.$parsers.push(function (val) {
+                        return parseInt(val, 10);
+                    });
+                    ngModel.$formatters.push(function (val) {
+                        return '' + val;
+                    });
+                }
+            };
+        });
+})();

--- a/src/GovITHub.Auth.Admin/wwwroot/app/index.route.js
+++ b/src/GovITHub.Auth.Admin/wwwroot/app/index.route.js
@@ -101,9 +101,51 @@
                         return $stateParams.id;
                     }]
                 }
+            }).state('index.users', {
+                url: "/users",
+                controller: "UsersListController as vm",
+                templateUrl: "app/components/users/list.html",
+                data: {
+                    pageTitle: 'Utilizatori'
+                }
+            })
+            .state('index.users_new', {
+                url: "/users/new",
+                controller: "UsersEditController as vm",
+                templateUrl: "app/components/users/edit.html",
+                data: {
+                    pageTitle: 'Utilizatori'
+                },
+                resolve: {
+                    status: [function () {
+                        return {
+                            edit: false
+                        };
+                    }],
+                    id: [function () {
+                        return null;
+                    }]
+                }
+            })
+            .state('index.users_edit', {
+                url: "/users/:id",
+                controller: "UsersEditController as vm",
+                templateUrl: "app/components/users/edit.html",
+                data: {
+                    pageTitle: 'Utilizatori'
+                },
+                resolve: {
+                    status: [function () {
+                        return {
+                            edit: true
+                        };
+                    }],
+                    id: ['$stateParams', function ($stateParams) {
+                        return $stateParams.id;
+                    }]
+                }
             });
 
         $urlRouterProvider.otherwise('/index/main');
     }
-
 })();

--- a/src/GovITHub.Auth.Common/Data/Contract/IOrganizationUserRepository.cs
+++ b/src/GovITHub.Auth.Common/Data/Contract/IOrganizationUserRepository.cs
@@ -1,0 +1,28 @@
+﻿namespace GovITHub.Auth.Common.Data.Contract
+{
+    public interface IOrganizationUserRepository
+    {
+        ModelQuery<OrganizationUser> Filter(long organizationId, ModelQueryFilter filter);
+
+        OrganizationUser Find(long organizationId, long id);
+
+        void Update(OrganizationUser organizationUser);
+
+        void Add(OrganizationUser organizationUser);
+
+        void Delete(long organizationId, long id);
+    }
+
+    public class OrganizationUser
+    {
+        public long Id { get; set; }
+
+        public long OrganizationId { get; set; }
+
+        public string Name { get; set; }
+
+        public Models.OrganizationUserLevel Level { get; set; }
+
+        public short Status { get; set; }
+    }
+}

--- a/src/GovITHub.Auth.Common/Data/Extensions/QueryableExtensions.cs
+++ b/src/GovITHub.Auth.Common/Data/Extensions/QueryableExtensions.cs
@@ -1,0 +1,31 @@
+﻿using System.Linq;
+
+namespace GovITHub.Auth.Common.Data
+{
+    public static class QueryableExtensions
+    {
+        public static IQueryable<T> Apply<T>(this IQueryable<T> query, Data.ModelQueryFilter queryFilter)
+        {
+            if (queryFilter != null)
+            {
+                if (!string.IsNullOrEmpty(queryFilter.SortBy))
+                {
+                    if (queryFilter.SortAscending)
+                    {
+                        query = query.OrderBy(queryFilter.SortBy);
+                    }
+                    else
+                    {
+                        query = query.OrderByDescending(queryFilter.SortBy);
+                    }
+                }
+
+                query = query
+                   .Skip(queryFilter.CurrentPage * queryFilter.ItemsPerPage)
+                   .Take(queryFilter.ItemsPerPage);
+            }
+
+            return query;
+        }
+    }
+}

--- a/src/GovITHub.Auth.Common/Data/Impl/OrganizationUserRepository.cs
+++ b/src/GovITHub.Auth.Common/Data/Impl/OrganizationUserRepository.cs
@@ -1,0 +1,98 @@
+﻿using Microsoft.EntityFrameworkCore;
+using System;
+using System.Linq;
+
+namespace GovITHub.Auth.Common.Data.Impl
+{
+    public class OrganizationUserRepository : Contract.IOrganizationUserRepository
+    {
+        private readonly ApplicationDbContext dbContext;
+
+        public OrganizationUserRepository(ApplicationDbContext dbContext)
+        {
+            this.dbContext = dbContext;
+        }
+
+        public ModelQuery<Contract.OrganizationUser> Filter(long organizationId, ModelQueryFilter filter)
+        {
+            IQueryable<Models.OrganizationUser> dbOrganizationUsersQuery = dbContext.OrganizationUsers.Where(x => x.OrganizationId == organizationId);
+
+            Contract.OrganizationUser[] organizationUsers = dbOrganizationUsersQuery.Include(x => x.User).Select(x =>
+                new
+                {
+                    Id = x.Id,
+                    Name = x.User.Email,
+                    Level = x.Level,
+                    Status = x.Status
+                }).Apply(filter).ToArray().Select(x => new Contract.OrganizationUser()
+                {
+                    Id = x.Id,
+                    Name = x.Name,
+                    Level = x.Level,
+                    Status = x.Status
+                }).ToArray();
+
+            return new ModelQuery<Contract.OrganizationUser>()
+            {
+                List = organizationUsers,
+                TotalItems = dbOrganizationUsersQuery.Count()
+            };
+        }
+
+        public Contract.OrganizationUser Find(long organizationId, long id)
+        {
+            Models.OrganizationUser dbOrganzationUser = dbContext.OrganizationUsers.Where(x => x.OrganizationId == organizationId).Include(x => x.User).FirstOrDefault(t => t.Id == id);
+
+            return new Contract.OrganizationUser()
+            {
+                Id = dbOrganzationUser.Id,
+                Name = dbOrganzationUser.User.Email,
+                Level = dbOrganzationUser.Level,
+                Status = dbOrganzationUser.Status
+            };
+        }
+
+        public void Update(Contract.OrganizationUser organizationUser)
+        {
+            Common.Models.ApplicationUser applicationUser = dbContext.Users.FirstOrDefault(x => x.Email == organizationUser.Name);
+
+            if (applicationUser == null)
+                throw new ArgumentOutOfRangeException("user", string.Format("User {0} does not exist!", organizationUser.Name));
+
+            Models.OrganizationUser dbOrganizationUser = dbContext.OrganizationUsers.FirstOrDefault(x => x.OrganizationId == organizationUser.OrganizationId && x.Id == organizationUser.Id);
+            dbOrganizationUser.Level = organizationUser.Level;
+            dbOrganizationUser.Status = organizationUser.Status;
+            dbOrganizationUser.UserId = applicationUser.Id;
+
+            dbContext.SaveChanges();
+        }
+
+        public void Add(Contract.OrganizationUser organizationUser)
+        {
+            Common.Models.ApplicationUser applicationUser = dbContext.Users.FirstOrDefault(x => x.Email == organizationUser.Name);
+
+            if (applicationUser == null)
+                throw new ArgumentOutOfRangeException("user", string.Format("User {0} does not exist!", organizationUser.Name));
+
+            Models.OrganizationUser dbOrganizationUser = new Models.OrganizationUser();
+            dbOrganizationUser.Level = organizationUser.Level;
+            dbOrganizationUser.Status = organizationUser.Status;
+            dbOrganizationUser.UserId = applicationUser.Id;
+            dbOrganizationUser.OrganizationId = organizationUser.OrganizationId;
+
+            dbContext.OrganizationUsers.Add(dbOrganizationUser);
+
+            dbContext.SaveChanges();
+        }
+
+        public void Delete(long organizationId, long id)
+        {
+            Models.OrganizationUser dbOrganizationUser = dbContext.OrganizationUsers.FirstOrDefault(x => x.OrganizationId == organizationId && x.Id == id);
+            if (dbOrganizationUser != null)
+            {
+                dbContext.OrganizationUsers.Remove(dbOrganizationUser);
+                dbContext.SaveChanges();
+            }
+        }
+    }
+}

--- a/src/GovITHub.Auth.Common/Data/Models/OrganizationUserLevel.cs
+++ b/src/GovITHub.Auth.Common/Data/Models/OrganizationUserLevel.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace GovITHub.Auth.Common.Data.Models
+﻿namespace GovITHub.Auth.Common.Data.Models
 {
     public enum OrganizationUserLevel
     {

--- a/src/GovITHub.Auth.Common/Data/OrganizationUserViewModel.cs
+++ b/src/GovITHub.Auth.Common/Data/OrganizationUserViewModel.cs
@@ -1,0 +1,13 @@
+﻿namespace GovITHub.Auth.Common.Data
+{
+    public class OrganizationUserViewModel
+    {
+        public long Id { get; set; }
+
+        public string Name { get; set; }
+
+        public Models.OrganizationUserLevel Level { get; set; }
+
+        public short Status { get; set; }
+    }
+}


### PR DESCRIPTION
* feat(organization-users): prototype CRUD Users - added controller  and repository #52

* feat(organization-users): prototype CRUD Users - register transient IOrganizationUserRepository #52

* feat(organization-users): prototype CRUD Users - uncomment the AuthorizeAttribute as the authentication process works now #52

* feat(organization-users): prototype CRUD Users - UI structure #52

* feat(organization-users): prototype CRUD Users - implement proper text messages and text labels. Added labels and inputs for organization user's fields #52

* feat(organization-users): prototype CRUD Users - rename all routes to 'users' as we already are in the context of a selected organization for which we alter the existing users #52

* feat(organization-users): prototype CRUD Users - fix diacritics in edit page #52

* feat(organization-users): prototype CRUD Users - endpoint for getting single organization user #52

* feat(organization-users): prototype CRUD Users - display the list of users. query uses annonymous types to be able to order by a specific property from the model and not from a navigation property. changed the way we attach the filter expressions because of a conflict with the annonymous types and thus Skip and Take are placed after OrderBy is attached #52

* feat(organization-users): prototype CRUD Users - implement edit page. added a new directive which serves as an adapter for the angular select which works with option values as strings. moved repository to Contract namespace and build a new class type Contract.OrganizationUser to decouple entity framework's from business models #52

* feat(organization-users): prototype CRUD Users - move IOrganizationUserRepository to Contract folder to resemble it's namespace #52

* feat(organization-users): prototype CRUD Users - persist organizationId in all Api calls as this is a security requirement. we will clean up organizationId later and move it inside the restful url 'api/organizations/:id/users' for a better allignment #52

* feat(organization-users): prototype CRUD Users - implement add organization user page #52

* feat(organization-users): prototype CRUD Users - implement delete organization user #52

* feat(organization-users): prototype CRUD Users - make organizationId part of the RESTFUL url. fixed a issue where the total number of users from an organization was calculated without filtering by the underlying organizationId #52

* feat(organization-users): prototype CRUD Users - remove organizationId from the parameter's list and added it to the model in cases in which it was more relevant. switched organizationId's priority in the parameters list as being a bigger deciding factor #52

* feat(organization-users): prototype CRUD Users - restrict access to organization users to users which are not linked to the organization #52

* feat(organization-users): prototype CRUD Users - move requirement handler into its own folder #52

* feat(organization-users): prototype CRUD Users - changes from code review. also fixed a security issue where a user could load information from an organization he wasn't assigned just because that specific organization had at least one user assigned to it #52

* feat(organization-users): prototype CRUD Users -remove slash '/' from stateProvider's templateUrl as it appears to work without it #52

* feat(organization-users): prototype CRUD Users -remove slash '/' ng-include as it appears to work without it #52

* feat(organization-users): prototype CRUD Users - changes after review #52